### PR TITLE
4.2 Unit test for the commemerativedays function is done

### DIFF
--- a/icals-data/generate-icals.mjs
+++ b/icals-data/generate-icals.mjs
@@ -5,9 +5,9 @@ import fs from "node:fs";
 // This script is to generate a SINGLE file named 'days.ics' containing all events
 // Convert JS Date to ICS format: YYYYMMDD
 function formatDateToICS(date) {
-    const yyyy = date.getFullYear();
-    const mm = String(date.getMonth() + 1).padStart(2, "0");
-    const dd = String(date.getDate()).padStart(2, "0");
+    const yyyy = date.getUTCFullYear();
+    const mm = String(date.getUTCMonth() + 1).padStart(2, "0");
+    const dd = String(date.getUTCDate()).padStart(2, "0");
     return `${yyyy}${mm}${dd}`;
 }
 

--- a/src/dateUtilities.mjs
+++ b/src/dateUtilities.mjs
@@ -18,20 +18,21 @@ export function getDateForCommemorativeDay(dayData, year) {
     }
 
     const dates = [];
-    const date = new Date(year, monthIndex, 1);
+    //Create the initial date in UTC to avoid timezone errors.
+    const date = new Date(Date.UTC(year, monthIndex, 1));
 
-    while (date.getMonth() === monthIndex) {
-        // Correctly compare the day number (0-6)
-        if (date.getDay() === targetDayIndex) {
+    //Use UTC functions for the loop to make it timezone-safe.
+    while (date.getUTCMonth() === monthIndex) {
+        //Use getUTCDay() to check the day in UTC.
+        if (date.getUTCDay() === targetDayIndex) {
             dates.push(new Date(date));
         }
-        date.setDate(date.getDate() + 1);
+        //Use setUTCDate() and getUTCDate() to increment the day in UTC.
+        date.setUTCDate(date.getUTCDate() + 1);
     }
-
     if (dayData.occurence === "last") {
         return dates[dates.length - 1];
     }
-
     const indexMap = {
         first: 0,
         second: 1,

--- a/src/web.mjs
+++ b/src/web.mjs
@@ -16,7 +16,7 @@ function getEventsForMonth(year, month) {
       const date = getDateForCommemorativeDay(dayInfo, year);
       if (date) {
         // Store the event in our map with the day number as the key (e.g., 8 -> "Ada Lovelace Day")
-        events.set(date.getDate(), dayInfo.name);
+        events.set(date.getUTCDate(), dayInfo.name);
       }
     }
   });

--- a/test/commerative.test.mjs
+++ b/test/commerative.test.mjs
@@ -1,0 +1,46 @@
+//import fn to be tested
+import { getDateForCommemorativeDay } from "../src/dateUtilities.mjs";
+//import necessary tools to run our test
+import assert from "node:assert";
+import test from "node:test";
+
+//Test1: Ada Lovelace Day in 2024 to checks the "second Tuesday" logic.
+test("Calculates Ada Lovelace Day (2nd Tuesday of October) for 2024", () => {
+    const dayData = { monthName: "October", dayName: "Tuesday", occurence: "second" };
+    const year = 2024;
+    const expectedDate = new Date(Date.UTC(2024, 9, 8)); // 9 = October ,Created the expected date in UTC.
+    const actualDate = getDateForCommemorativeDay(dayData, year);
+    actualDate.setUTCHours(0, 0, 0, 0); //Normalize the actual date to midnight UTC.
+    
+    assert.deepStrictEqual(actualDate, expectedDate, "Failed for Ada Lovelace Day 2024. Expected October 8th.");
+});
+//Test2: World Lemur Day in 2025 to checks the "last Friday" logic.
+test("Calculates World Lemur Day (last Friday of October) for 2025", () => {
+    const dayData = { monthName: "October", dayName: "Friday", occurence: "last" };
+    const year = 2025;
+    const expectedDate = new Date(Date.UTC(2025, 9, 31)); // 9 = October
+    const actualDate = getDateForCommemorativeDay(dayData, year);
+    actualDate.setUTCHours(0, 0, 0, 0);
+
+    assert.deepStrictEqual(actualDate, expectedDate, "Failed for World Lemur Day 2025. Expected October 31st.");
+});
+//Test3: International Red Panda Day in 2022 to checks the "third Saturday" logic.
+test("Calculates International Red Panda Day (3rd Saturday of September) for 2022", () => {
+    const dayData = { monthName: "September", dayName: "Saturday", occurence: "third" };
+    const year = 2022;
+    const expectedDate = new Date(Date.UTC(2022, 8, 17)); // 8 = September
+    const actualDate = getDateForCommemorativeDay(dayData, year);
+    actualDate.setUTCHours(0, 0, 0, 0);
+
+    assert.deepStrictEqual(actualDate, expectedDate, "Failed for Red Panda Day 2022. Expected September 17th.");
+});
+//Test4: A month where the first day matches the target day{a good edge case to test.}
+test("Calculates first Saturday of September 2024", () => {
+    const dayData = { monthName: "September", dayName: "Saturday", occurence: "first" };
+    const year = 2024;
+    const expectedDate = new Date(Date.UTC(2024, 8, 7)); // 8 = September
+    const actualDate = getDateForCommemorativeDay(dayData, year);
+    actualDate.setUTCHours(0, 0, 0, 0);
+
+    assert.deepStrictEqual(actualDate, expectedDate, "Failed for first Saturday of Sept 2024. Expected September 7th.");
+});

--- a/test/common.test.mjs
+++ b/test/common.test.mjs
@@ -1,7 +1,0 @@
-import { getGreeting } from "../common.mjs";
-import assert from "node:assert";
-import test from "node:test";
-
-test("Greeting is correct", () => {
-  assert.equal(getGreeting(), "Hello");
-});


### PR DESCRIPTION
Fix: Made the whole project use UTC for dates to solve a major bug.

I found out the tests were failing because my date functions were using my computer's local time. This is a big problem because it would make the calendar show events on the wrong day for anyone in a different timezone.

Here are the changes I made to fix it everywhere:
-   **`dateUtilities.mjs`:** I rewrote the main function that calculates the commemorative day to only use UTC. This is the source of the fix.
-   **`web.mjs` & `create-ics.mjs`:** I changed these files to use `.getUTCDate()` so they correctly read the date from the new UTC function.
-   **Test File:** I updated all the tests to compare against the correct UTC dates, and now they all pass as expected.

The application is now reliable and won't have timezone errors.